### PR TITLE
Add 'craft_guide' mod as optional dependency:

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,3 +1,4 @@
 stairs
 default
 moreblocks?
+craft_guide?


### PR DESCRIPTION
Add compatibility with [cornernote's *craft_guide* mod](http://cornernote.github.io/minetest-craft_guide/) to ensure that craft recipes are registered.