### PR TITLE
Replace deprecated method 'setting_getbool' with 'settings:get_bool'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -506,7 +506,7 @@ minetest.register_craftitem(":default:mese_crystal_fragment", {
 	on_place = function(stack, _, pt)
 		if pt.under and minetest.get_node(pt.under).name == "default:obsidian" then
 			local done = make_portal(pt.under)
-			if done and not minetest.setting_getbool("creative_mode") then
+			if done and not minetest.settings:get_bool("creative_mode") then
 				stack:take_item()
 			end
 		end


### PR DESCRIPTION
May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267